### PR TITLE
Tracer version bump

### DIFF
--- a/packages/tracer/package.json
+++ b/packages/tracer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logzio-node-toolbox/tracer",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "multi-functional trace",
   "main": "dist/index.cjs",
   "exports": {


### PR DESCRIPTION
I messed up and published version 0.0.11 without dist, compile step didn't run for some reason when did the commit for the first time. Now I need to bump version to be able to publish again.

I unpublished broken version 0.0.11 so it's not publicly available on npm.