### PR TITLE
DEV-35047 Add ability to omit fields on specific roots

### DIFF
--- a/.github/workflows/git-secrets.yml
+++ b/.github/workflows/git-secrets.yml
@@ -32,4 +32,5 @@ jobs:
           git secrets --register-aws 
       - name: Running scanning tool
         run:
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           git secrets --scan

--- a/.github/workflows/git-secrets.yml
+++ b/.github/workflows/git-secrets.yml
@@ -9,7 +9,7 @@ jobs:
   # This workflow contains a single job called "main"
   git-secrets:
     # The type of runner that the job will run on
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -25,6 +25,8 @@ jobs:
           sudo apt-get install git less openssh-server
       - name: Installing scanning tool
         run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          ln -s "$(which echo)" /usr/local/bin/say
           brew install git-secrets
           git secrets --install
           git secrets --register-aws 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@typescript-eslint/parser": "^5.2.0",
     "babel-jest": "^27.3.1",
     "core-js": "^3.19.0",
-    "eslint": "^8.1.0",
+    "eslint": "8.22.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^4.0.0",
     "husky": "7.0.4",

--- a/packages/logger/__test__/formatters/omitFields.test.js
+++ b/packages/logger/__test__/formatters/omitFields.test.js
@@ -1,11 +1,53 @@
-import { omitFields } from '../../src/formatters/omitFields.js';
+import { omitFields } from '../../src/formatters/';
 
 describe('formatter - omitFields', () => {
   it('should remove fields', () => {
-    const log = { omit1: '12', nested: { omit2: '12' }, name: 'boya' };
+    const log = {
+      omit1: '12',
+      nested: { omit2: '12' },
+      name: 'boya',
+    };
 
     const modifiedLog = omitFields(['omit1', 'nested.omit2'])(log);
 
-    expect(modifiedLog).toEqual({ name: 'boya', nested: {} });
+    expect(modifiedLog).toEqual({
+      nested: {},
+      name: 'boya',
+    });
+  });
+
+  it('should remove fields from specified log path root', () => {
+    const log = {
+      omit: '12',
+      nested: { omit: '12', notOmit: true },
+      name: 'boya',
+    };
+
+    const modifiedLog = omitFields(['omit'], ['nested'])(log);
+
+    expect(modifiedLog).toEqual({
+      nested: { notOmit: true },
+      name: 'boya',
+    });
+  });
+
+  it('should remove complex fields from specified log path root', () => {
+    const log = {
+      omitContainer: { omit: '12' },
+      nested: {
+        omitContainer: { omit: '12', notOmit: true },
+      },
+      name: 'boya',
+    };
+
+    const modifiedLog = omitFields(['omitContainer.omit'], ['nested'])(log);
+
+    expect(modifiedLog).toEqual({
+      omitContainer: {},
+      nested: {
+        omitContainer: { notOmit: true },
+      },
+      name: 'boya',
+    });
   });
 });

--- a/packages/logger/src/formatters/omitFields.js
+++ b/packages/logger/src/formatters/omitFields.js
@@ -1,7 +1,11 @@
 import _ from 'lodash';
 
-export function omitFields(fieldsToOmit = []) {
+export function omitFields(fieldsToOmit = [], omitFieldsPathRoots = []) {
   return function omitFieldsLog(log) {
-    return _.omit(log, fieldsToOmit);
+    const result = _.omit(log, fieldsToOmit);
+    return omitFieldsPathRoots.reduce(
+      (acc, pathRoot) => (acc[pathRoot] ? { ...acc, [pathRoot]: _.omit(acc[pathRoot], fieldsToOmit) } : acc),
+      result,
+    );
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1798,10 +1798,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@eslint/eslintrc@^1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.3.1.tgz#de0807bfeffc37b964a7d0400e0c348ce5a2543d"
-  integrity sha512-OhSY22oQQdw3zgPOOwdoj01l/Dzl1Z+xyUP33tkSN+aqyEhymJCcPHyXt+ylW8FSe0TfRC2VG+ROQOapD0aZSQ==
+"@eslint/eslintrc@^1.3.0":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.3.3.tgz#2b044ab39fdfa75b4688184f9e573ce3c5b0ff95"
+  integrity sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==
   dependencies:
     ajv "^6.12.4"
     debug "^4.3.2"
@@ -1838,9 +1838,9 @@
     "@hapi/hoek" "^9.0.0"
 
 "@humanwhocodes/config-array@^0.10.4":
-  version "0.10.4"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.10.4.tgz#01e7366e57d2ad104feea63e72248f22015c520c"
-  integrity sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==
+  version "0.10.7"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.10.7.tgz#6d53769fd0c222767e6452e8ebda825c22e9f0dc"
+  integrity sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==
   dependencies:
     "@humanwhocodes/object-schema" "^1.2.1"
     debug "^4.1.1"
@@ -1850,11 +1850,6 @@
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/gitignore-to-minimatch/-/gitignore-to-minimatch-1.0.2.tgz#316b0a63b91c10e53f242efb4ace5c3b34e8728d"
   integrity sha512-rSqmMJDdLFUsyxR6FMtD00nfQKKLFb1kv+qBbOVKqErvloEIJLo5bDTJTQNTYgeyp78JsA7u/NPi5jT1GR/MuA==
-
-"@humanwhocodes/module-importer@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz#af5b2691a22b44be847b0ca81641c5fb6ad0172c"
-  integrity sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==
 
 "@humanwhocodes/object-schema@^1.2.1":
   version "1.2.1"
@@ -5049,15 +5044,14 @@ eslint-visitor-keys@^3.3.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
-eslint@^8.1.0:
-  version "8.23.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.23.0.tgz#a184918d288820179c6041bb3ddcc99ce6eea040"
-  integrity sha512-pBG/XOn0MsJcKcTRLr27S5HpzQo4kLr+HjLQIyK4EiCsijDl/TB+h5uEuJU6bQ8Edvwz1XWOjpaP2qgnXGpTcA==
+eslint@8.22.0:
+  version "8.22.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.22.0.tgz#78fcb044196dfa7eef30a9d65944f6f980402c48"
+  integrity sha512-ci4t0sz6vSRKdmkOGmprBo6fmI4PrphDFMy5JEq/fNS0gQkJM3rLmrqcp8ipMcdobH3KtUP40KniAE9W19S4wA==
   dependencies:
-    "@eslint/eslintrc" "^1.3.1"
+    "@eslint/eslintrc" "^1.3.0"
     "@humanwhocodes/config-array" "^0.10.4"
     "@humanwhocodes/gitignore-to-minimatch" "^1.0.2"
-    "@humanwhocodes/module-importer" "^1.0.1"
     ajv "^6.10.0"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
@@ -5067,7 +5061,7 @@ eslint@^8.1.0:
     eslint-scope "^7.1.1"
     eslint-utils "^3.0.0"
     eslint-visitor-keys "^3.3.0"
-    espree "^9.4.0"
+    espree "^9.3.3"
     esquery "^1.4.0"
     esutils "^2.0.2"
     fast-deep-equal "^3.1.3"
@@ -5093,6 +5087,16 @@ eslint@^8.1.0:
     strip-ansi "^6.0.1"
     strip-json-comments "^3.1.0"
     text-table "^0.2.0"
+    v8-compile-cache "^2.0.3"
+
+espree@^9.3.3:
+  version "9.4.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.4.1.tgz#51d6092615567a2c2cff7833445e37c28c0065bd"
+  integrity sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==
+  dependencies:
+    acorn "^8.8.0"
+    acorn-jsx "^5.3.2"
+    eslint-visitor-keys "^3.3.0"
 
 espree@^9.4.0:
   version "9.4.0"
@@ -10421,6 +10425,11 @@ uuid@^3.2.1, uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+v8-compile-cache@^2.0.3:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
+  integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
 
 v8-to-istanbul@^8.1.0:
   version "8.1.1"


### PR DESCRIPTION
**Before:**
- No ability to specify the omit fields path root to cleaning logs more efficiently

**After:**
- We can specify the path root, so omitter will clean specified fields inside of proper object(s). Please check tests for examples.

**Additionally:**
- Pinned ESLint package version to 8.22.0 because there is an issue in 8.23.0 which blocks some linter check flows. Details: https://youtrack.jetbrains.com/issue/WEB-57089/ESLint8.23-TypeError-this.libOptions.parse-is-not-a-function
- New and old unit-tests passed:

<img width="655" alt="image" src="https://user-images.githubusercontent.com/5207710/204526538-8461d964-f0b6-4638-a4f8-5fab3f3ca46f.png">
